### PR TITLE
fix: wire "Get In Touch" button on projects page to contact modal

### DIFF
--- a/src/app/projects/layout.tsx
+++ b/src/app/projects/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import ContactModal from "@/components/ContactModal";
 
 export const metadata: Metadata = {
   title: "Projects | Corey - Software Developer",
@@ -36,6 +37,7 @@ export default function ProjectsLayout({
       <main className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
         {children}
       </main>
+      <ContactModal />
     </div>
   );
 }

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -1,8 +1,11 @@
-import Link from "next/link";
+"use client";
+
 import { projects } from "@/data/projects";
 import ProjectCarousel from "@/components/ProjectCarousel";
+import { useContactModal } from "@/store/useContactModal";
 
 const Projects = () => {
+  const { openModal } = useContactModal();
   const featuredProject = projects.find(p => p.featured);
   const otherProjects = projects.filter(p => !p.featured);
 
@@ -173,12 +176,12 @@ const Projects = () => {
           I&apos;m always excited to take on new challenges and create meaningful digital solutions.
           Let&apos;s discuss how we can bring your ideas to life.
         </p>
-        <Link
-          href="/#contact"
+        <button
+          onClick={openModal}
           className="inline-flex items-center justify-center px-8 py-3 text-base font-medium rounded-lg bg-accent text-accent-foreground hover:bg-accent/90 focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2 transition-colors duration-200"
         >
           Get In Touch
-        </Link>
+        </button>
       </section>
     </div>
   );


### PR DESCRIPTION
Replaced the Link (routing to /#contact) with a button that opens the contact modal via the useContactModal Zustand store. Added ContactModal to the projects layout so it renders on the /projects route.

https://claude.ai/code/session_01CuHKJEDhKMboJE98PhxKwR