### PR TITLE
fix(ci): bump Claude review --max-turns from 5 to 25

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -33,4 +33,4 @@ jobs:
             - TypeScript correctness and type safety
             - Tailwind/React best practices for Next.js projects
             Post your findings as inline review comments on the relevant lines.
-          claude_args: "--max-turns 5"
+          claude_args: "--max-turns 25"


### PR DESCRIPTION
The action consistently failed with error_max_turns. A multi-file PR review needs more than 5 turns: read PR metadata, list changed files, read each file, gather context, post inline comments.