### PR TITLE
feat: replace portfolio meta-project with Mill Creek + add Vercel Analytics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@emotion/styled": "^11.14.1",
         "@marsidev/react-turnstile": "^1.4.2",
         "@mui/material": "^7.3.8",
+        "@vercel/analytics": "^2.0.1",
         "lucide-react": "^1.11.0",
         "next": "^16.1.6",
         "next-themes": "^0.4.6",
@@ -2482,6 +2483,48 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-2.0.1.tgz",
+      "integrity": "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
     },
     "node_modules/acorn": {
       "version": "8.15.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@emotion/styled": "^11.14.1",
     "@marsidev/react-turnstile": "^1.4.2",
     "@mui/material": "^7.3.8",
+    "@vercel/analytics": "^2.0.1",
     "lucide-react": "^1.11.0",
     "next": "^16.1.6",
     "next-themes": "^0.4.6",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import { Analytics } from "@vercel/analytics/next";
 import "./globals.css";
 import { Providers } from "./providers";
 import Navbar from "@/components/Navbar";
@@ -53,6 +54,7 @@ export default function RootLayout({
           <Navbar />
           {children}
         </Providers>
+        <Analytics />
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary
- Replace the portfolio's meta-project entry with the Mill Creek Farm & Feed case study
- Add Vercel Analytics to the root layout to start collecting production pageview data

## Test plan
- [ ] Preview deploy loads without console errors
- [ ] Mill Creek project card appears on /projects and links to its detail page
- [ ] Vercel Analytics dashboard starts receiving events after merge to production

🤖 Generated with [Claude Code](https://claude.com/claude-code)