### PR TITLE
chore: remove broken View Code buttons and github field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+.claude/scratch/

--- a/src/app/projects/[slug]/page.tsx
+++ b/src/app/projects/[slug]/page.tsx
@@ -203,16 +203,6 @@ export default async function ProjectPage({
               View Live Demo →
             </a>
           )}
-          {project.links.github && project.links.github !== '#' && (
-            <a
-              href={project.links.github}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex items-center justify-center px-6 py-3 text-base font-medium rounded-lg border border-foreground/20 text-foreground hover:bg-foreground/5 focus:outline-none focus:ring-2 focus:ring-foreground/20 focus:ring-offset-2 transition-colors duration-200"
-            >
-              View Source Code →
-            </a>
-          )}
         </section>
 
         {/* Back to Projects */}

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -198,14 +198,6 @@ const Projects = () => {
                       Live Demo →
                     </a>
                   )}
-                  <a
-                    href={project.links.github}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-sm text-foreground/70 hover:text-foreground font-medium transition-colors duration-200"
-                  >
-                    View Code →
-                  </a>
                 </div>
               </div>
             </div>

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -13,7 +13,6 @@ export const projects: Project[] = [
     featured: true,
     links: {
       demo: 'https://carhauler.vercel.app/',
-      github: '#', // Add your GitHub repo URL here
       case_study: 'https://youtu.be/oV3YRHReBpc',
     },
     images: {
@@ -62,7 +61,6 @@ export const projects: Project[] = [
     featured: false,
     links: {
       demo: 'https://stoic-quote-gen.vercel.app/',
-      github: '#', // Add your GitHub repo URL here
     },
     images: {
       hero: '/projects/stoic-quotes-hero.jpg',
@@ -104,7 +102,6 @@ export const projects: Project[] = [
     featured: false,
     links: {
       demo: 'https://premier-barbershop.vercel.app/',
-      github: '#', // Add your GitHub repo URL here
     },
     images: {
       hero: '/projects/barbershop-hero.jpg',
@@ -150,7 +147,6 @@ export const projects: Project[] = [
     featured: false,
     links: {
       demo: 'https://mill-creek-ruddy.vercel.app/',
-      github: '#',
     },
     images: {
       hero: '/projects/mill-creek-hero.jpg',
@@ -193,7 +189,6 @@ export const projects: Project[] = [
     featured: false,
     links: {
       demo: 'https://height-table.vercel.app/',
-      github: '#',
     },
     images: {
       hero: '/projects/height-table-hero.png',

--- a/src/types/Project.ts
+++ b/src/types/Project.ts
@@ -1,6 +1,5 @@
 export interface ProjectLinks {
   demo?: string;
-  github?: string;
   case_study?: string;
 }
 


### PR DESCRIPTION
## Summary
- Removed the "View Code →" button on the projects listing — every project's `github` was `'#'`, so it just refreshed the same page
- Removed the gated "View Source Code →" button on project detail pages (also tied to the same unused field)
- Stripped `github?` from `ProjectLinks` and removed all 5 `github: '#'` entries from project data

## Test plan
- [x] `npm run lint` clean
- [x] `npm run build` passes (TypeScript + all 12 static pages generated)
- [ ] Visual check: projects listing shows only "Live Demo →" links; detail pages show only "View Live Demo" CTA

🤖 Generated with [Claude Code](https://claude.com/claude-code)